### PR TITLE
Add Support of Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Each project is tagged consistently, so when pulling these repos, pull the same 
 |---	|---	| --- |
 | Red Hat® Enterprise Linux® 8.5 	|  [redhat/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/redhat/main) | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/redhat/main/README.md)| 
 | SUSE® Linux® Enterprise Server 15SP3	| [suse/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/suse/main) |[Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/suse/main/README.md)|
-| Ubuntu® 20.04 ( linux-oem image 5.14) 	|[ubuntu/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/ubuntu/main)| [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/ubuntu/main/README.md)|
+| Ubuntu® 22.04 (linux-oem image 5.17) 	|[ubuntu/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/ubuntu/main)| [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/ubuntu/main/README.md)|
+| Ubuntu® 20.04 (linux-oem image 5.14) 	|[ubuntu/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/ubuntu/main)| [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/ubuntu/main/README.md)|
+
 
 
 


### PR DESCRIPTION
Using same branch for Ubuntu 20.04 and Ubuntu 22.04.

Ubuntu 22.04: linux-oem 5.17
Ubuntu 20.04: linux-oem 5.14

Signed-off-by: Ayaz A Siddiqui <ayaz.siddiqui@intel.com>