### PR TITLE
Add Support of RHEL 8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each project is tagged consistently, so when pulling these repos, pull the same 
 
 |   OSV |Branch   	| installation instructions | 
 |---	|---	| --- |
+| Red Hat® Enterprise Linux® 8.6 	|  [redhat/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/redhat/main) | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/redhat/main/README.md)|
 | Red Hat® Enterprise Linux® 8.5 	|  [redhat/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/redhat/main) | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/redhat/main/README.md)| 
 | SUSE® Linux® Enterprise Server 15SP3	| [suse/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/suse/main) |[Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/suse/main/README.md)|
 | Ubuntu® 22.04 (linux-oem image 5.17) 	|[ubuntu/main](https://github.com/intel-gpu/intel-gpu-i915-backports/tree/ubuntu/main)| [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/ubuntu/main/README.md)|


### PR DESCRIPTION
Using same branch for RHEL 8.5 and RHEL8.6

RHEL 8.6: kernel-4.18.372
RHEL 8.5: kernel-4.18.348

Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>