### PR TITLE
Remove i915 dkms build dependency on Host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ mrproper:
 	echo "| for more options."							;\
 	echo "\\--"									;\
 	false)
+ifeq (,$(filter i915dkmsdeb-pkg i915dkmsrpm-pkg, $(MAKECMDGOALS)))
 	@set -e ; test -f $(KERNEL_CONFIG) || (						\
 	echo "/--------------"								;\
 	echo "| Your kernel headers are incomplete/not installed."			;\
@@ -116,6 +117,7 @@ mrproper:
 		echo " done."								;\
 	fi										;\
 	echo "$(CONFIG_MD5)" > .kernel_config_md5
+endif
 	@$(MAKE) -f Makefile.real "$@"
 
 .PHONY: defconfig-help


### PR DESCRIPTION
i915 dkms package generation has dependency on
host machine which is throwing error When we build
under a non-target OS and CPU.

This change will remove the build dependency on host
machine.

Signed-off-by: Kolanupaka Naveena <kolanupaka.naveena@intel.com>
Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>