### PR TITLE
build: compatible with ubuntu 22.04 v5.15 kernel

### DIFF
--- a/backport-include/drm/drm_dp_helper.h
+++ b/backport-include/drm/drm_dp_helper.h
@@ -3,7 +3,7 @@
 
 #include_next  <drm/drm_dp_helper.h>
 
-#if LINUX_VERSION_IN_RANGE(5,14,0, 5,15,0)
+#if LINUX_VERSION_IN_RANGE(5,14,0, 5,16,0)
 #define drm_dp_get_adjust_tx_ffe_preset LINUX_I915_BACKPORT(drm_dp_get_adjust_tx_ffe_preset)
 u8 drm_dp_get_adjust_tx_ffe_preset(const u8 link_status[DP_LINK_STATUS_SIZE],
 				   int lane);
@@ -67,6 +67,7 @@ int drm_edp_backlight_enable(struct drm_dp_aux *aux, const struct drm_edp_backli
 #define drm_edp_backlight_disable LINUX_I915_BACKPORT(drm_edp_backlight_disable)
 int drm_edp_backlight_disable(struct drm_dp_aux *aux, const struct drm_edp_backlight_info *bl);
 
+#define drm_edp_backlight_supported LINUX_I915_BACKPORT(drm_edp_backlight_supported)
 static inline bool
 drm_edp_backlight_supported(const u8 edp_dpcd[EDP_DISPLAY_CTL_CAP_SIZE])
 {

--- a/backport-include/linux/backport_macro.h
+++ b/backport-include/linux/backport_macro.h
@@ -132,6 +132,12 @@
 
 #endif
 
+#if LINUX_VERSION_IN_RANGE(5,15,0, 5,16,0)
+
+#define MSO_PIXEL_OVERLAP_DISPLAY_NOT_PRESENT
+
+#endif
+
 #if LINUX_VERSION_IS_GEQ(5,14,0)
 
 /* 

--- a/backport-include/uapi/drm/drm_fourcc.h
+++ b/backport-include/uapi/drm/drm_fourcc.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-#if LINUX_VERSION_IN_RANGE(5,17,0, 5,18,0)
+#if LINUX_VERSION_IN_RANGE(5,15,0, 5,18,0)
 /**
  * DRM_FORMAT_MAX_PLANES - maximum number of planes a DRM format can have
  */

--- a/compat/backport-5.10.c
+++ b/compat/backport-5.10.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2021 Intel Corporation
  */
-#if LINUX_VERSION_IN_RANGE(5,14,0, 5,15,0)
+#if LINUX_VERSION_IN_RANGE(5,14,0, 5,16,0)
 
 #include <drm/drm_dp_helper.h>
 #include <drm/drm_print.h>

--- a/compat/slub.c
+++ b/compat/slub.c
@@ -44,7 +44,7 @@ static inline unsigned long node_nr_slabs(struct kmem_cache_node *n)
 #define count_free  LINUX_I915_BACKPORT(count_free)
 #define node_nr_objs  LINUX_I915_BACKPORT(node_nr_objs)
 
-#if LINUX_VERSION_IN_RANGE(5,14,0, 5,15,0)
+#if LINUX_VERSION_IN_RANGE(5,14,0, 5,16,0)
 static int count_free(struct page *page)
 {
 	return page->objects - page->inuse;
@@ -79,7 +79,7 @@ static inline unsigned int oo_objects(struct kmem_cache_order_objects x)
 
 #if defined(CONFIG_SLUB_DEBUG) || defined(CONFIG_SYSFS)
 
-#if LINUX_VERSION_IN_RANGE(5,14,0, 5,15,0)
+#if LINUX_VERSION_IN_RANGE(5,14,0, 5,16,0)
 static unsigned long count_partial(struct kmem_cache_node *n,
 					int (*get_count)(struct page *))
 {


### PR DESCRIPTION
I try to build with linux-image-generic kernel (linux-image-5.15.0-56-generic), the dkms complains building error, suck as lack of  definition. I fix them.

It works well in ubuntu 22.04.1, NUCi5PAH.

Signed-off-by: fu.lin <linfu@autox.ai>