### PR TITLE
README: Remove 5.19 generic info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ backport/main will point to the currently supported version of Ubuntu® and SLES
 
 | OS Distribution | OS Version | Kernel Version  | Installation Instructions |
 |---  |---  |---  |--- |
-| Ubuntu® | 22.04 | Kernel 5.19 generic | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md) |
-| | 22.04 | Kernel 5.17 oem | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md) |
+| Ubuntu® | 22.04 | Kernel 5.17 oem | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md) |
 | | 20.04 | Kernel 5.15 generic | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md) |
-| | Mainline LTS |  Kernel 5.15.72 | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md) |
+| | Mainline LTS |  Kernel 5.15 | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md) |
 | SLES | 15SP4 | Kernel 5.14 | [README](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_sles.md) |
 
 # Product Releases:

--- a/docs/README_ubuntu.md
+++ b/docs/README_ubuntu.md
@@ -5,8 +5,7 @@
 
 | OS Distribution | OS Version | Kernel Version  |
 |---  |---  |---  |
-| Ubuntu® | 22.04 | Kernel 5.19 generic |
-| | 22.04 | Kernel 5.17 oem |
+| Ubuntu® | 22.04 | Kernel 5.17 oem |
 | | 20.04 | Kernel 5.15 generic |
 
   The kernel header used at the time of backporting may not be compatible with the latest version at the time of installation.


### PR DESCRIPTION
In this release, Ubuntu 22.04 5.19 generic support is
not enabled as per version file. So removed 5.19 generic
info from README.

Signed-off-by: Nitin Gote <nitin.r.gote@intel.com>