### PR TITLE
i915 backport headless

### DIFF
--- a/drivers/gpu/drm/i915/Kconfig
+++ b/drivers/gpu/drm/i915/Kconfig
@@ -99,6 +99,16 @@ config DRM_I915_USERPTR
 
 	  If in doubt, say "Y".
 
+config DRM_I915_DISPLAY
+	bool "Enable display support"
+	depends on DRM_I915
+	default n
+	help
+	  Choose this option if you want to enable display support.
+	  Say "N" for headless support.
+
+	  If in doubt, say "Y".
+
 config DRM_I915_GVT
 	bool "Enable Intel GVT-g graphics virtualization host support"
 	depends on DRM_I915

--- a/drivers/gpu/drm/i915/Makefile
+++ b/drivers/gpu/drm/i915/Makefile
@@ -44,7 +44,6 @@ i915-y += i915_driver.o \
 	  i915_pci.o \
 	  i915_pci_err.o \
 	  i915_scatterlist.o \
-	  i915_suspend.o \
 	  i915_switcheroo.o \
 	  i915_sysfs.o \
 	  i915_sysrq.o \
@@ -55,7 +54,6 @@ i915-y += i915_driver.o \
 	  intel_memory_region.o \
 	  intel_pch.o \
 	  intel_pcode.o \
-	  intel_pm.o \
 	  intel_runtime_pm.o \
 	  intel_sbi.o \
 	  intel_step.o \
@@ -65,6 +63,9 @@ i915-y += i915_driver.o \
 	  intel_wakeref.o \
 	  vlv_sideband.o \
 	  vlv_suspend.o
+i915-$(CPTCFG_DRM_I915_DISPLAY) += \
+	  i915_suspend.o \
+	  intel_pm.o
 
 # core library code
 i915-y += \
@@ -79,9 +80,13 @@ i915-y += \
 i915-$(CONFIG_COMPAT)   += i915_ioc32.o
 i915-$(CONFIG_DEBUG_FS) += \
 	i915_debugfs.o \
-	i915_debugfs_params.o \
+	i915_debugfs_params.o
+
+ifeq ($(CPTCFG_DRM_I915_DISPLAY),y)
+i915-$(CONFIG_DEBUG_FS) += \
 	display/intel_display_debugfs.o \
 	display/intel_pipe_crc.o
+endif
 
 i915-$(CONFIG_PERF_EVENTS) += i915_pmu.o
 i915-$(CPTCFG_DRM_I915_DEBUGGER) += i915_debugger.o
@@ -266,20 +271,22 @@ i915-$(CONFIG_HWMON) += i915_hwmon.o
 
 # modesetting core code
 i915-y += \
+	display/intel_cdclk.o \
+	display/intel_display.o
+
+i915-$(CPTCFG_DRM_I915_DISPLAY) += \
 	display/hsw_ips.o \
 	display/intel_atomic.o \
 	display/intel_atomic_plane.o \
 	display/intel_audio.o \
 	display/intel_bios.o \
 	display/intel_bw.o \
-	display/intel_cdclk.o \
 	display/intel_color.o \
 	display/intel_combo_phy.o \
 	display/intel_connector.o \
 	display/intel_crtc.o \
 	display/intel_crtc_state_dump.o \
 	display/intel_cursor.o \
-	display/intel_display.o \
 	display/intel_display_power.o \
 	display/intel_display_power_map.o \
 	display/intel_display_power_well.o \
@@ -315,14 +322,17 @@ i915-y += \
 	display/i9xx_plane.o \
 	display/skl_scaler.o \
 	display/skl_universal_plane.o
+
+ifeq ($(CPTCFG_DRM_I915_DISPLAY),y)
 i915-$(CONFIG_ACPI) += \
 	display/intel_acpi.o \
 	display/intel_opregion.o
 i915-$(CPTCFG_DRM_FBDEV_EMULATION) += \
 	display/intel_fbdev.o
+endif
 
-# modesetting output/encoder code
-i915-y += \
+## modesetting output/encoder code
+i915-$(CPTCFG_DRM_I915_DISPLAY) += \
 	display/dvo_ch7017.o \
 	display/dvo_ch7xxx.o \
 	display/dvo_ivch.o \
@@ -392,8 +402,11 @@ i915-$(CPTCFG_DRM_I915_SELFTEST) += \
 	selftests/igt_mmap.o \
 	selftests/igt_reset.o \
 	selftests/igt_spinner.o \
-	selftests/librapl.o \
+	selftests/librapl.o
+ifeq ($(CPTCFG_DRM_I915_DISPLAY),y)
+i915-$(CPTCFG_DRM_I915_SELFTEST) += \
 	display/selftests/selftest_display.o
+endif
 
 # virtual gpu code
 i915-y += i915_vgpu.o

--- a/drivers/gpu/drm/i915/display/intel_cdclk.c
+++ b/drivers/gpu/drm/i915/display/intel_cdclk.c
@@ -38,6 +38,7 @@
 #include "intel_psr.h"
 #include "vlv_sideband.h"
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #define MTL_CDCLK_THRESHOLD	307200
 
 #define HAS_SQUASH_AND_CRAWL(i915)	(has_cdclk_squasher(i915) && HAS_CDCLK_CRAWL(i915))
@@ -3191,6 +3192,7 @@ void intel_update_cdclk(struct drm_i915_private *dev_priv)
 		intel_de_write(dev_priv, GMBUSFREQ_VLV,
 			       DIV_ROUND_UP(dev_priv->cdclk.hw.cdclk, 1000));
 }
+#endif
 
 static int dg1_rawclk(struct drm_i915_private *dev_priv)
 {
@@ -3336,6 +3338,7 @@ u32 intel_read_rawclk(struct drm_i915_private *dev_priv)
 	return freq;
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static const struct intel_cdclk_funcs mtl_cdclk_funcs = {
 	.get_cdclk = mtl_get_cdclk,
 	.set_cdclk = mtl_set_cdclk,
@@ -3556,3 +3559,4 @@ void intel_init_cdclk_hooks(struct drm_i915_private *dev_priv)
 		     "Unknown platform. Assuming i830\n"))
 		dev_priv->cdclk_funcs = &i830_cdclk_funcs;
 }
+#endif

--- a/drivers/gpu/drm/i915/display/intel_display.c
+++ b/drivers/gpu/drm/i915/display/intel_display.c
@@ -121,6 +121,7 @@
 #include "vlv_dsi_regs.h"
 #include "vlv_sideband.h"
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void intel_set_transcoder_timings(const struct intel_crtc_state *crtc_state);
 static void intel_set_pipe_src_size(const struct intel_crtc_state *crtc_state);
 static void hsw_set_transconf(const struct intel_crtc_state *crtc_state);
@@ -221,6 +222,7 @@ static int intel_compute_global_watermarks(struct intel_atomic_state *state)
 		return dev_priv->wm_disp->compute_global_watermarks(state);
 	return 0;
 }
+#endif
 
 /* returns HPLL frequency in kHz */
 int vlv_get_hpll_vco(struct drm_i915_private *dev_priv)
@@ -267,6 +269,7 @@ int vlv_get_cck_clock_hpll(struct drm_i915_private *dev_priv,
 	return hpll;
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void intel_update_czclk(struct drm_i915_private *dev_priv)
 {
 	if (!(IS_VALLEYVIEW(dev_priv) || IS_CHERRYVIEW(dev_priv)))
@@ -639,6 +642,7 @@ unsigned int intel_rotation_info_size(const struct intel_rotation_info *rot_info
 
 	return size;
 }
+#endif
 
 unsigned int intel_remapped_info_size(const struct intel_remapped_info *rem_info)
 {
@@ -665,6 +669,7 @@ unsigned int intel_remapped_info_size(const struct intel_remapped_info *rem_info
 	return size;
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 bool intel_plane_uses_fence(const struct intel_plane_state *plane_state)
 {
 	struct intel_plane *plane = to_intel_plane(plane_state->uapi.plane);
@@ -9178,6 +9183,7 @@ void intel_display_driver_unregister(struct drm_i915_private *i915)
 	acpi_video_unregister();
 	intel_opregion_unregister(i915);
 }
+#endif
 
 bool intel_scanout_needs_vtd_wa(struct drm_i915_private *i915)
 {

--- a/drivers/gpu/drm/i915/display/intel_display.h
+++ b/drivers/gpu/drm/i915/display/intel_display.h
@@ -547,8 +547,16 @@ void intel_link_compute_m_n(u16 bpp, int nlanes,
 			    int pixel_clock, int link_clock,
 			    struct intel_link_m_n *m_n,
 			    bool constant_n, bool fec_enable);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 u32 intel_plane_fb_max_stride(struct drm_i915_private *dev_priv,
 			      u32 pixel_format, u64 modifier);
+#else
+static inline u32 intel_plane_fb_max_stride(struct drm_i915_private *dev_priv,
+			      u32 pixel_format, u64 modifier)
+{
+	return 0;
+}
+#endif
 enum drm_mode_status
 intel_mode_valid_max_plane_size(struct drm_i915_private *dev_priv,
 				const struct drm_display_mode *mode,

--- a/drivers/gpu/drm/i915/gem/i915_gem_domain.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_domain.c
@@ -4,7 +4,9 @@
  * Copyright © 2014-2016 Intel Corporation
  */
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/intel_frontbuffer.h"
+#endif
 #include "gt/intel_gt.h"
 
 #include "i915_drv.h"

--- a/drivers/gpu/drm/i915/gem/i915_gem_object.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_object.c
@@ -29,7 +29,9 @@
 #include <drm/drm_cache.h>
 #include <drm/drm_print.h>
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/intel_frontbuffer.h"
+#endif
 #include "gt/intel_flat_ppgtt_pool.h"
 #include "gt/intel_gpu_commands.h"
 #include "gt/intel_gt.h"
@@ -1263,6 +1265,7 @@ finish_src:
 void __i915_gem_object_flush_frontbuffer(struct drm_i915_gem_object *obj,
 					 enum fb_op_origin origin)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	struct intel_frontbuffer *front;
 
 	front = __intel_frontbuffer_get(obj);
@@ -1270,11 +1273,13 @@ void __i915_gem_object_flush_frontbuffer(struct drm_i915_gem_object *obj,
 		intel_frontbuffer_flush(front, origin);
 		intel_frontbuffer_put(front);
 	}
+#endif
 }
 
 void __i915_gem_object_invalidate_frontbuffer(struct drm_i915_gem_object *obj,
 					      enum fb_op_origin origin)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	struct intel_frontbuffer *front;
 
 	front = __intel_frontbuffer_get(obj);
@@ -1282,6 +1287,7 @@ void __i915_gem_object_invalidate_frontbuffer(struct drm_i915_gem_object *obj,
 		intel_frontbuffer_invalidate(front, origin);
 		intel_frontbuffer_put(front);
 	}
+#endif
 }
 
 static void

--- a/drivers/gpu/drm/i915/gt/intel_ggtt.c
+++ b/drivers/gpu/drm/i915/gt/intel_ggtt.c
@@ -1811,6 +1811,7 @@ void i915_ggtt_resume(struct i915_ggtt *ggtt)
 	intel_ggtt_restore_fences(ggtt);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static struct scatterlist *
 rotate_pages(struct drm_i915_gem_object *obj, unsigned int offset,
 	     unsigned int width, unsigned int height,
@@ -1902,6 +1903,7 @@ err_st_alloc:
 
 	return ERR_PTR(ret);
 }
+#endif
 
 static struct scatterlist *
 add_padding_pages(unsigned int count,
@@ -2177,8 +2179,12 @@ i915_get_ggtt_vma_pages(struct i915_vma *vma)
 		return 0;
 
 	case I915_GGTT_VIEW_ROTATED:
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		vma->pages =
 			intel_rotate_pages(&vma->ggtt_view.rotated, vma->obj);
+#else
+		drm_err(&vma->vm->i915->drm, "NO DISPLAY!\n");
+#endif
 		break;
 
 	case I915_GGTT_VIEW_REMAPPED:

--- a/drivers/gpu/drm/i915/gt/intel_ggtt_fencing.c
+++ b/drivers/gpu/drm/i915/gt/intel_ggtt_fencing.c
@@ -351,8 +351,10 @@ static struct i915_fence_reg *fence_find(struct i915_ggtt *ggtt)
 	}
 
 	/* Wait for completion of pending flips which consume fences */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (intel_has_pending_fb_unpin(ggtt->vm.i915))
 		return ERR_PTR(-EAGAIN);
+#endif
 
 	return ERR_PTR(-EDEADLK);
 }

--- a/drivers/gpu/drm/i915/gt/intel_gsc.c
+++ b/drivers/gpu/drm/i915/gt/intel_gsc.c
@@ -309,7 +309,9 @@ static void gsc_init_one(struct drm_i915_private *i915, struct intel_gsc *gsc,
 #endif
 	struct intel_gsc_intf *intf = &gsc->intf[intf_id];
 	bool use_polling = false;
+#if IS_ENABLED(CONFIG_AUXILIARY_BUS)
 	bool forcewake_needed = false;
+#endif
 	int ret;
 
 	intf->irq = -1;

--- a/drivers/gpu/drm/i915/gt/intel_gt_pm.c
+++ b/drivers/gpu/drm/i915/gt/intel_gt_pm.c
@@ -91,7 +91,9 @@ static void runtime_end(struct intel_gt *gt)
 static int __gt_unpark(struct intel_wakeref *wf)
 {
 	struct intel_gt *gt = container_of(wf, typeof(*gt), wakeref);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	struct drm_i915_private *i915 = gt->i915;
+#endif
 
 	GT_TRACE(gt, "\n");
 
@@ -109,8 +111,10 @@ static int __gt_unpark(struct intel_wakeref *wf)
 	 * Work around it by grabbing a GT IRQ power domain whilst there is any
 	 * GT activity, preventing any DC state transitions.
 	 */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	gt->awake = intel_display_power_get(i915, POWER_DOMAIN_GT_IRQ);
 	GEM_BUG_ON(!gt->awake);
+#endif
 
 	i915_vma_unpark(gt);
 	intel_rc6_unpark(&gt->rc6);
@@ -127,7 +131,9 @@ static int __gt_unpark(struct intel_wakeref *wf)
 static int __gt_park(struct intel_wakeref *wf)
 {
 	struct intel_gt *gt = container_of(wf, typeof(*gt), wakeref);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	intel_wakeref_t wakeref = fetch_and_zero(&gt->awake);
+#endif
 	struct drm_i915_private *i915 = gt->i915;
 
 	GT_TRACE(gt, "\n");
@@ -148,8 +154,10 @@ static int __gt_park(struct intel_wakeref *wf)
 	intel_synchronize_irq(i915);
 
 	/* Defer dropping the display power well for 100ms, it's slow! */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	GEM_BUG_ON(!wakeref);
 	intel_display_power_put_async(i915, POWER_DOMAIN_GT_IRQ, wakeref);
+#endif
 
 	/* Wa_14017210380: mtl */
 	mtl_mc6_wa_media_not_busy(gt);

--- a/drivers/gpu/drm/i915/gt/intel_reset.c
+++ b/drivers/gpu/drm/i915/gt/intel_reset.c
@@ -7,8 +7,10 @@
 #include <linux/stop_machine.h>
 #include <linux/string_helpers.h>
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/intel_display.h"
 #include "display/intel_overlay.h"
+#endif
 
 #include "gem/i915_gem_context.h"
 
@@ -1315,7 +1317,9 @@ void intel_gt_reset(struct intel_gt *gt,
 	if (INTEL_INFO(gt->i915)->gpu_reset_clobbers_display)
 		intel_runtime_pm_enable_interrupts(gt->i915);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	intel_overlay_reset(gt->i915);
+#endif
 
 	/*
 	 * Next we need to restore the context, but we don't use those
@@ -1460,11 +1464,13 @@ static void intel_gt_reset_global(struct intel_gt *gt,
 
 	/* Use a watchdog to ensure that our reset completes */
 	intel_wedge_on_timeout(&w, gt, 60 * HZ) {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		intel_display_prepare_reset(gt->i915);
-
 		intel_gt_reset(gt, engine_mask, reason);
-
 		intel_display_finish_reset(gt->i915);
+#else
+		intel_gt_reset(gt, engine_mask, reason);
+#endif
 	}
 
 	if (!test_bit(I915_WEDGED, &gt->reset.flags))

--- a/drivers/gpu/drm/i915/i915_gem.c
+++ b/drivers/gpu/drm/i915/i915_gem.c
@@ -39,8 +39,10 @@
 #include <drm/drm_cache.h>
 #include <drm/drm_vma_manager.h>
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/intel_display.h"
 #include "display/intel_frontbuffer.h"
+#endif
 
 #include "gem/i915_gem_clflush.h"
 #include "gem/i915_gem_context.h"
@@ -1193,7 +1195,9 @@ int i915_gem_init(struct drm_i915_private *dev_priv)
 	 *
 	 * FIXME: break up the workarounds and apply them at the right time!
 	 */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	intel_init_clock_gating(dev_priv);
+#endif
 
 	if (HAS_UM_QUEUES(dev_priv))
 		xa_init_flags(&dev_priv->asid_resv.xa, XA_FLAGS_ALLOC);
@@ -1238,7 +1242,9 @@ err_unlock:
 		/* Minimal basic recovery for KMS */
 		ret = i915_ggtt_enable_hw(dev_priv);
 		i915_ggtt_resume(to_gt(dev_priv)->ggtt);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		intel_init_clock_gating(dev_priv);
+#endif
 	}
 
 	i915_gem_drain_freed_objects(dev_priv);

--- a/drivers/gpu/drm/i915/i915_gpu_error.c
+++ b/drivers/gpu/drm/i915/i915_gpu_error.c
@@ -39,8 +39,10 @@
 #include <drm/drm_cache.h>
 #include <drm/drm_print.h>
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/intel_dmc.h"
 #include "display/intel_overlay.h"
+#endif
 
 #include "gem/i915_gem_context.h"
 #include "gem/i915_gem_lmem.h"
@@ -963,7 +965,9 @@ static void __err_print_to_sgl(struct drm_i915_error_state_buf *m,
 
 	err_printf(m, "IOMMU enabled?: %d\n", error->iommu);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	intel_dmc_print_error_state(m, m->i915);
+#endif
 
 	err_printf(m, "RPM wakelock: %s\n", str_yes_no(error->wakelock));
 	err_printf(m, "PM suspended: %s\n", str_yes_no(error->suspended));
@@ -1003,8 +1007,10 @@ static void __err_print_to_sgl(struct drm_i915_error_state_buf *m,
 		err_print_gt_attentions(m, error->gt);
 	}
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (error->overlay)
 		intel_overlay_print_error_state(m, error->overlay);
+#endif
 
 	err_print_capabilities(m, error);
 	err_print_params(m, &error->params);
@@ -1219,7 +1225,9 @@ void __i915_gpu_coredump_free(struct kref *error_ref)
 		cleanup_gt(gt);
 	}
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	kfree(error->overlay);
+#endif
 
 	cleanup_params(error);
 
@@ -2502,7 +2510,9 @@ i915_gpu_coredump(struct intel_gt *gt, intel_engine_mask_t engine_mask, u32 dump
 		error->simulated |= error->gt->simulated;
 	}
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	error->overlay = intel_overlay_capture_error_state(i915);
+#endif
 
 	return error;
 }

--- a/drivers/gpu/drm/i915/i915_irq.c
+++ b/drivers/gpu/drm/i915/i915_irq.c
@@ -35,6 +35,7 @@
 
 #include <drm/drm_drv.h>
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/icl_dsi_regs.h"
 #include "display/intel_de.h"
 #include "display/intel_display_trace.h"
@@ -43,6 +44,7 @@
 #include "display/intel_hotplug.h"
 #include "display/intel_lpe_audio.h"
 #include "display/intel_psr.h"
+#endif
 
 #include "gt/intel_breadcrumbs.h"
 #include "gt/intel_gt.h"
@@ -83,6 +85,7 @@ static inline void pmu_irq_stats(struct drm_i915_private *i915,
 	WRITE_ONCE(i915->pmu.irq_count, i915->pmu.irq_count + 1);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 typedef bool (*long_pulse_detect_func)(enum hpd_pin pin, u32 val);
 typedef u32 (*hotplug_enables_func)(struct drm_i915_private *i915,
 				    enum hpd_pin pin);
@@ -255,6 +258,7 @@ intel_handle_vblank(struct drm_i915_private *dev_priv, enum pipe pipe)
 
 	drm_crtc_handle_vblank(&crtc->base);
 }
+#endif
 
 void gen3_irq_reset(struct intel_uncore *uncore, i915_reg_t imr,
 		    i915_reg_t iir, i915_reg_t ier)
@@ -422,6 +426,7 @@ void ilk_disable_display_irq(struct drm_i915_private *i915, u32 bits)
  * @interrupt_mask: mask of interrupt bits to update
  * @enabled_irq_mask: mask of interrupt bits to enable
  */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void bdw_update_port_irq(struct drm_i915_private *dev_priv,
 				u32 interrupt_mask,
 				u32 enabled_irq_mask)
@@ -447,6 +452,7 @@ static void bdw_update_port_irq(struct drm_i915_private *dev_priv,
 		intel_uncore_posting_read(&dev_priv->uncore, GEN8_DE_PORT_IMR);
 	}
 }
+#endif
 
 /**
  * bdw_update_pipe_irq - update DE pipe interrupt
@@ -696,6 +702,7 @@ static void i915_enable_asle_pipestat(struct drm_i915_private *dev_priv)
 /* Called from drm generic code, passed a 'crtc', which
  * we use as a pipe index
  */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 u32 i915_get_vblank_counter(struct drm_crtc *crtc)
 {
 	struct drm_i915_private *dev_priv = to_i915(crtc->dev);
@@ -1050,6 +1057,7 @@ int intel_get_crtc_scanline(struct intel_crtc *crtc)
 
 	return position;
 }
+#endif
 
 /**
  * ivb_parity_work - Workqueue called when a parity error interrupt
@@ -1134,6 +1142,7 @@ out:
 	mutex_unlock(&dev_priv->drm.struct_mutex);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static bool gen11_port_hotplug_long_detect(enum hpd_pin pin, u32 val)
 {
 	switch (pin) {
@@ -1324,6 +1333,7 @@ static u32 intel_hpd_hotplug_enables(struct drm_i915_private *i915,
 
 	return hotplug;
 }
+#endif
 
 static void gmbus_irq_handler(struct drm_i915_private *dev_priv)
 {
@@ -1335,6 +1345,7 @@ static void dp_aux_irq_handler(struct drm_i915_private *dev_priv)
 	wake_up_all(&dev_priv->gmbus_wait_queue);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #if defined(CONFIG_DEBUG_FS)
 static void display_pipe_crc_irq_handler(struct drm_i915_private *dev_priv,
 					 enum pipe pipe,
@@ -1438,6 +1449,7 @@ static void i9xx_pipe_crc_irq_handler(struct drm_i915_private *dev_priv,
 				     intel_uncore_read(&dev_priv->uncore, PIPE_CRC_RES_BLUE(pipe)),
 				     res1, res2);
 }
+#endif
 
 static void i9xx_pipestat_irq_reset(struct drm_i915_private *dev_priv)
 {
@@ -1518,6 +1530,7 @@ static void i9xx_pipestat_irq_ack(struct drm_i915_private *dev_priv,
 	spin_unlock(&dev_priv->irq_lock);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void i8xx_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 				      u16 iir, u32 pipe_stats[I915_MAX_PIPES])
 {
@@ -1558,10 +1571,12 @@ static void i915_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 	if (blc_event || (iir & I915_ASLE_INTERRUPT))
 		intel_opregion_asle_intr(dev_priv);
 }
+#endif
 
 static void i965_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 				      u32 iir, u32 pipe_stats[I915_MAX_PIPES])
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	bool blc_event = false;
 	enum pipe pipe;
 
@@ -1581,6 +1596,7 @@ static void i965_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 
 	if (blc_event || (iir & I915_ASLE_INTERRUPT))
 		intel_opregion_asle_intr(dev_priv);
+#endif
 
 	if (pipe_stats[0] & PIPE_GMBUS_INTERRUPT_STATUS)
 		gmbus_irq_handler(dev_priv);
@@ -1589,6 +1605,7 @@ static void i965_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 static void valleyview_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 					    u32 pipe_stats[I915_MAX_PIPES])
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	enum pipe pipe;
 
 	for_each_pipe(dev_priv, pipe) {
@@ -1604,11 +1621,13 @@ static void valleyview_pipestat_irq_handler(struct drm_i915_private *dev_priv,
 		if (pipe_stats[pipe] & PIPE_FIFO_UNDERRUN_STATUS)
 			intel_cpu_fifo_underrun_irq_handler(dev_priv, pipe);
 	}
+#endif
 
 	if (pipe_stats[0] & PIPE_GMBUS_INTERRUPT_STATUS)
 		gmbus_irq_handler(dev_priv);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static u32 i9xx_hpd_irq_ack(struct drm_i915_private *dev_priv)
 {
 	u32 hotplug_status = 0, hotplug_status_mask;
@@ -1673,6 +1692,16 @@ static void i9xx_hpd_irq_handler(struct drm_i915_private *dev_priv,
 	    hotplug_status & DP_AUX_CHANNEL_MASK_INT_STATUS_G4X)
 		dp_aux_irq_handler(dev_priv);
 }
+#else
+static u32 i9xx_hpd_irq_ack(struct drm_i915_private *dev_priv)
+{
+	return 0;
+}
+static void i9xx_hpd_irq_handler(struct drm_i915_private *dev_priv,
+				 u32 hotplug_status)
+{
+}
+#endif
 
 static irqreturn_t valleyview_irq_handler(int irq, void *arg)
 {
@@ -1729,9 +1758,11 @@ static irqreturn_t valleyview_irq_handler(int irq, void *arg)
 		 * signalled in iir */
 		i9xx_pipestat_irq_ack(dev_priv, iir, pipe_stats);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		if (iir & (I915_LPE_PIPE_A_INTERRUPT |
 			   I915_LPE_PIPE_B_INTERRUPT))
 			intel_lpe_audio_irq_handler(dev_priv);
+#endif
 
 		/*
 		 * VLV_IIR is single buffered, and reflects the level
@@ -1812,10 +1843,12 @@ static irqreturn_t cherryview_irq_handler(int irq, void *arg)
 		 * signalled in iir */
 		i9xx_pipestat_irq_ack(dev_priv, iir, pipe_stats);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		if (iir & (I915_LPE_PIPE_A_INTERRUPT |
 			   I915_LPE_PIPE_B_INTERRUPT |
 			   I915_LPE_PIPE_C_INTERRUPT))
 			intel_lpe_audio_irq_handler(dev_priv);
+#endif
 
 		/*
 		 * VLV_IIR is single buffered, and reflects the level
@@ -1843,6 +1876,7 @@ static irqreturn_t cherryview_irq_handler(int irq, void *arg)
 static void ibx_hpd_irq_handler(struct drm_i915_private *dev_priv,
 				u32 hotplug_trigger)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	u32 dig_hotplug_reg, pin_mask = 0, long_mask = 0;
 
 	/*
@@ -1870,6 +1904,7 @@ static void ibx_hpd_irq_handler(struct drm_i915_private *dev_priv,
 			   pch_port_hotplug_long_detect);
 
 	intel_hpd_irq_handler(dev_priv, pin_mask, long_mask);
+#endif
 }
 
 static void ibx_irq_handler(struct drm_i915_private *dev_priv, u32 pch_iir)
@@ -1915,21 +1950,26 @@ static void ibx_irq_handler(struct drm_i915_private *dev_priv, u32 pch_iir)
 		drm_dbg(&dev_priv->drm,
 			"PCH transcoder CRC error interrupt\n");
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (pch_iir & SDE_TRANSA_FIFO_UNDER)
 		intel_pch_fifo_underrun_irq_handler(dev_priv, PIPE_A);
 
 	if (pch_iir & SDE_TRANSB_FIFO_UNDER)
 		intel_pch_fifo_underrun_irq_handler(dev_priv, PIPE_B);
+#endif
 }
 
 static void ivb_err_int_handler(struct drm_i915_private *dev_priv)
 {
 	u32 err_int = intel_uncore_read(&dev_priv->uncore, GEN7_ERR_INT);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	enum pipe pipe;
+#endif
 
 	if (err_int & ERR_INT_POISON)
 		drm_err(&dev_priv->drm, "Poison interrupt\n");
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	for_each_pipe(dev_priv, pipe) {
 		if (err_int & ERR_INT_FIFO_UNDERRUN(pipe))
 			intel_cpu_fifo_underrun_irq_handler(dev_priv, pipe);
@@ -1941,6 +1981,7 @@ static void ivb_err_int_handler(struct drm_i915_private *dev_priv)
 				hsw_pipe_crc_irq_handler(dev_priv, pipe);
 		}
 	}
+#endif
 
 	intel_uncore_write(&dev_priv->uncore, GEN7_ERR_INT, err_int);
 }
@@ -1948,14 +1989,18 @@ static void ivb_err_int_handler(struct drm_i915_private *dev_priv)
 static void cpt_serr_int_handler(struct drm_i915_private *dev_priv)
 {
 	u32 serr_int = intel_uncore_read(&dev_priv->uncore, SERR_INT);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	enum pipe pipe;
+#endif
 
 	if (serr_int & SERR_INT_POISON)
 		drm_err(&dev_priv->drm, "PCH poison interrupt\n");
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	for_each_pipe(dev_priv, pipe)
 		if (serr_int & SERR_INT_TRANS_FIFO_UNDERRUN(pipe))
 			intel_pch_fifo_underrun_irq_handler(dev_priv, pipe);
+#endif
 
 	intel_uncore_write(&dev_priv->uncore, SERR_INT, serr_int);
 }
@@ -1997,6 +2042,7 @@ static void cpt_irq_handler(struct drm_i915_private *dev_priv, u32 pch_iir)
 		cpt_serr_int_handler(dev_priv);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void xelpdp_pica_irq_handler(struct drm_i915_private *dev_priv, u32 iir)
 {
 	enum hpd_pin pin;
@@ -2125,25 +2171,31 @@ static void ilk_hpd_irq_handler(struct drm_i915_private *dev_priv,
 
 	intel_hpd_irq_handler(dev_priv, pin_mask, long_mask);
 }
+#endif
 
 static void ilk_display_irq_handler(struct drm_i915_private *dev_priv,
 				    u32 de_iir)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	enum pipe pipe;
 	u32 hotplug_trigger = de_iir & DE_DP_A_HOTPLUG;
 
 	if (hotplug_trigger)
 		ilk_hpd_irq_handler(dev_priv, hotplug_trigger);
+#endif
 
 	if (de_iir & DE_AUX_CHANNEL_A)
 		dp_aux_irq_handler(dev_priv);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (de_iir & DE_GSE)
 		intel_opregion_asle_intr(dev_priv);
+#endif
 
 	if (de_iir & DE_POISON)
 		drm_err(&dev_priv->drm, "Poison interrupt\n");
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	for_each_pipe(dev_priv, pipe) {
 		if (de_iir & DE_PIPE_VBLANK(pipe))
 			intel_handle_vblank(dev_priv, pipe);
@@ -2157,6 +2209,7 @@ static void ilk_display_irq_handler(struct drm_i915_private *dev_priv,
 		if (de_iir & DE_PIPE_CRC_DONE(pipe))
 			i9xx_pipe_crc_irq_handler(dev_priv, pipe);
 	}
+#endif
 
 	/* check event from PCH */
 	if (de_iir & DE_PCH_EVENT) {
@@ -2178,11 +2231,13 @@ static void ilk_display_irq_handler(struct drm_i915_private *dev_priv,
 static void ivb_display_irq_handler(struct drm_i915_private *dev_priv,
 				    u32 de_iir)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	enum pipe pipe;
 	u32 hotplug_trigger = de_iir & DE_DP_A_HOTPLUG_IVB;
 
 	if (hotplug_trigger)
 		ilk_hpd_irq_handler(dev_priv, hotplug_trigger);
+#endif
 
 	if (de_iir & DE_ERR_INT_IVB)
 		ivb_err_int_handler(dev_priv);
@@ -2190,6 +2245,7 @@ static void ivb_display_irq_handler(struct drm_i915_private *dev_priv,
 	if (de_iir & DE_AUX_CHANNEL_A_IVB)
 		dp_aux_irq_handler(dev_priv);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (de_iir & DE_GSE_IVB)
 		intel_opregion_asle_intr(dev_priv);
 
@@ -2200,6 +2256,7 @@ static void ivb_display_irq_handler(struct drm_i915_private *dev_priv,
 		if (de_iir & DE_PLANE_FLIP_DONE_IVB(pipe))
 			flip_done_handler(dev_priv, pipe);
 	}
+#endif
 
 	/* check event from PCH */
 	if (!HAS_PCH_NOP(dev_priv) && (de_iir & DE_PCH_EVENT_IVB)) {
@@ -2290,6 +2347,7 @@ static irqreturn_t ilk_irq_handler(int irq, void *arg)
 	return ret;
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void bxt_hpd_irq_handler(struct drm_i915_private *dev_priv,
 				u32 hotplug_trigger)
 {
@@ -2716,6 +2774,7 @@ gen8_de_irq_handler(struct drm_i915_private *dev_priv, u32 master_ctl)
 
 	return ret;
 }
+#endif
 
 static inline u32 gen8_master_intr_disable(void __iomem * const regs)
 {
@@ -2756,7 +2815,9 @@ static irqreturn_t gen8_irq_handler(int irq, void *arg)
 	/* IRQs are synced during runtime_suspend, we don't require a wakeref */
 	if (master_ctl & ~GEN8_GT_IRQS) {
 		disable_rpm_wakeref_asserts(&dev_priv->runtime_pm);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		gen8_de_irq_handler(dev_priv, master_ctl);
+#endif
 		enable_rpm_wakeref_asserts(&dev_priv->runtime_pm);
 	}
 
@@ -3758,8 +3819,10 @@ gen11_gu_misc_irq_ack(struct drm_i915_private *i915, const u32 master_ctl)
 static void
 gen11_gu_misc_irq_handler(struct drm_i915_private *i915, const u32 iir)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (iir & GEN11_GU_MISC_GSE)
 		intel_opregion_asle_intr(i915);
+#endif
 }
 
 static inline u32 gen11_master_intr_disable(void __iomem * const regs)
@@ -3780,6 +3843,7 @@ static inline void gen11_master_intr_enable(void __iomem * const regs)
 	raw_reg_write(regs, GEN11_GFX_MSTR_IRQ, GEN11_MASTER_IRQ);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void
 gen11_display_irq_handler(struct drm_i915_private *i915)
 {
@@ -3798,6 +3862,7 @@ gen11_display_irq_handler(struct drm_i915_private *i915)
 
 	enable_rpm_wakeref_asserts(&i915->runtime_pm);
 }
+#endif
 
 static irqreturn_t gen11_irq_handler(int irq, void *arg)
 {
@@ -3820,8 +3885,10 @@ static irqreturn_t gen11_irq_handler(int irq, void *arg)
 	gen11_gt_irq_handler(gt, master_ctl);
 
 	/* IRQs are synced during runtime_suspend, we don't require a wakeref */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (master_ctl & GEN11_DISPLAY_IRQ)
 		gen11_display_irq_handler(i915);
+#endif
 
 	gu_misc_iir = gen11_gu_misc_irq_ack(i915, master_ctl);
 
@@ -3911,8 +3978,10 @@ static irqreturn_t dg1_irq_handler(int irq, void *arg)
 		 * it doesn't hurt to check the bit on each tile just to be
 		 * safe.
 		 */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		if (master_ctl & GEN11_DISPLAY_IRQ)
 			gen11_display_irq_handler(i915);
+#endif
 
 		gu_misc_iir |= gen11_gu_misc_irq_ack(i915, master_ctl);
 	}
@@ -3966,6 +4035,7 @@ static int vf_mem_irq_postinstall(struct drm_i915_private *i915)
 /* Called from drm generic code, passed 'crtc' which
  * we use as a pipe index
  */
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 int i8xx_enable_vblank(struct drm_crtc *crtc)
 {
 	struct drm_i915_private *dev_priv = to_i915(crtc->dev);
@@ -4147,6 +4217,7 @@ void bdw_disable_vblank(struct drm_crtc *_crtc)
 	bdw_disable_pipe_irq(dev_priv, pipe, GEN8_PIPE_VBLANK);
 	spin_unlock_irqrestore(&dev_priv->irq_lock, irqflags);
 }
+#endif
 
 static void ibx_irq_reset(struct drm_i915_private *dev_priv)
 {
@@ -4245,6 +4316,7 @@ static void valleyview_irq_reset(struct drm_i915_private *dev_priv)
 	spin_unlock_irq(&dev_priv->irq_lock);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void gen8_display_irq_reset(struct drm_i915_private *dev_priv)
 {
 	struct intel_uncore *uncore = &dev_priv->uncore;
@@ -4264,6 +4336,7 @@ static void gen8_display_irq_reset(struct drm_i915_private *dev_priv)
 	GEN3_IRQ_RESET(uncore, GEN8_DE_PORT_);
 	GEN3_IRQ_RESET(uncore, GEN8_DE_MISC_);
 }
+#endif
 
 static void gen8_irq_reset(struct drm_i915_private *dev_priv)
 {
@@ -4272,7 +4345,9 @@ static void gen8_irq_reset(struct drm_i915_private *dev_priv)
 	gen8_master_intr_disable(dev_priv->uncore.regs);
 
 	gen8_gt_irq_reset(to_gt(dev_priv));
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	gen8_display_irq_reset(dev_priv);
+#endif
 	GEN3_IRQ_RESET(uncore, GEN8_PCU_);
 
 	if (HAS_PCH_SPLIT(dev_priv))
@@ -4280,6 +4355,8 @@ static void gen8_irq_reset(struct drm_i915_private *dev_priv)
 
 }
 
+
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void gen11_display_irq_reset(struct drm_i915_private *dev_priv)
 {
 	struct intel_uncore *uncore = &dev_priv->uncore;
@@ -4326,6 +4403,7 @@ static void gen11_display_irq_reset(struct drm_i915_private *dev_priv)
 	if (INTEL_PCH_TYPE(dev_priv) >= PCH_ICP)
 		GEN3_IRQ_RESET(uncore, SDE);
 }
+#endif
 
 static void gen11_irq_reset(struct drm_i915_private *dev_priv)
 {
@@ -4335,7 +4413,9 @@ static void gen11_irq_reset(struct drm_i915_private *dev_priv)
 	gen11_master_intr_disable(dev_priv->uncore.regs);
 
 	gen11_gt_irq_reset(gt);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	gen11_display_irq_reset(dev_priv);
+#endif
 
 	if (!IS_SRIOV_VF(dev_priv)) {
 		GEN3_IRQ_RESET(uncore, GEN11_GU_MISC_);
@@ -4359,9 +4439,12 @@ static void dg1_irq_reset(struct drm_i915_private *dev_priv)
 		GEN3_IRQ_RESET(uncore, GEN8_PCU_);
 	}
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	gen11_display_irq_reset(dev_priv);
+#endif
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 void gen8_irq_power_well_post_enable(struct drm_i915_private *dev_priv,
 				     u8 pipe_mask)
 {
@@ -4385,6 +4468,7 @@ void gen8_irq_power_well_post_enable(struct drm_i915_private *dev_priv,
 
 	spin_unlock_irq(&dev_priv->irq_lock);
 }
+#endif
 
 void gen8_irq_power_well_pre_disable(struct drm_i915_private *dev_priv,
 				     u8 pipe_mask)
@@ -4425,6 +4509,7 @@ static void cherryview_irq_reset(struct drm_i915_private *dev_priv)
 	spin_unlock_irq(&dev_priv->irq_lock);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static u32 ibx_hotplug_enables(struct drm_i915_private *i915,
 			       enum hpd_pin pin)
 {
@@ -4931,6 +5016,7 @@ static void bxt_hpd_irq_setup(struct drm_i915_private *dev_priv)
 
 	bxt_hpd_detection_setup(dev_priv);
 }
+#endif
 
 /*
  * SDEIER is also touched by the interrupt handler to work around missed PCH
@@ -5046,6 +5132,7 @@ static void valleyview_irq_postinstall(struct drm_i915_private *dev_priv)
 	intel_uncore_posting_read(&dev_priv->uncore, VLV_MASTER_IER);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void gen8_de_irq_postinstall(struct drm_i915_private *dev_priv)
 {
 	struct intel_uncore *uncore = &dev_priv->uncore;
@@ -5142,6 +5229,7 @@ static void mtp_irq_postinstall(struct drm_i915_private *dev_priv)
 
 	GEN3_IRQ_INIT(uncore, SDE, ~sde_mask, 0xffffffff);
 }
+#endif
 
 static void icp_irq_postinstall(struct drm_i915_private *dev_priv)
 {
@@ -5159,11 +5247,14 @@ static void gen8_irq_postinstall(struct drm_i915_private *dev_priv)
 		ibx_irq_postinstall(dev_priv);
 
 	gen8_gt_irq_postinstall(to_gt(dev_priv));
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	gen8_de_irq_postinstall(dev_priv);
+#endif
 
 	gen8_master_intr_enable(dev_priv->uncore.regs);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void gen11_de_irq_postinstall(struct drm_i915_private *dev_priv)
 {
 	if (!HAS_DISPLAY(dev_priv))
@@ -5174,6 +5265,7 @@ static void gen11_de_irq_postinstall(struct drm_i915_private *dev_priv)
 	intel_uncore_write(&dev_priv->uncore, GEN11_DISPLAY_INT_CTL,
 			   GEN11_DISPLAY_IRQ_ENABLE);
 }
+#endif
 
 static void gen11_irq_postinstall(struct drm_i915_private *dev_priv)
 {
@@ -5185,7 +5277,9 @@ static void gen11_irq_postinstall(struct drm_i915_private *dev_priv)
 		icp_irq_postinstall(dev_priv);
 
 	gen11_gt_irq_postinstall(gt);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	gen11_de_irq_postinstall(dev_priv);
+#endif
 
 	if (!IS_SRIOV_VF(dev_priv))
 		GEN3_IRQ_INIT(uncore, GEN11_GU_MISC_, ~gu_misc_masked, gu_misc_masked);
@@ -5253,6 +5347,7 @@ static void dg1_irq_postinstall(struct drm_i915_private *dev_priv)
 		intel_uncore_write(gt->uncore, GEN11_GFX_MSTR_IRQ, REG_GENMASK(30, 0));
 	}
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (HAS_DISPLAY(dev_priv)) {
 		if (DISPLAY_VER(dev_priv) >= 14)
 			mtp_irq_postinstall(dev_priv);
@@ -5263,6 +5358,7 @@ static void dg1_irq_postinstall(struct drm_i915_private *dev_priv)
 		intel_uncore_write(&dev_priv->uncore, GEN11_DISPLAY_INT_CTL,
 				   GEN11_DISPLAY_IRQ_ENABLE);
 	}
+#endif
 
 	intel_uncore_write(&dev_priv->uncore, DG1_MSTR_TILE_INTR, REG_GENMASK(3, 0));
 	dg1_master_intr_enable(to_gt(dev_priv)->uncore->regs);
@@ -5439,7 +5535,9 @@ static irqreturn_t i8xx_irq_handler(int irq, void *arg)
 		if (iir & I915_MASTER_ERROR_INTERRUPT)
 			i8xx_error_irq_handler(dev_priv, eir, eir_stuck);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		i8xx_pipestat_irq_handler(dev_priv, iir, pipe_stats);
+#endif
 	} while (0);
 
 	pmu_irq_stats(dev_priv, ret);
@@ -5550,7 +5648,9 @@ static irqreturn_t i915_irq_handler(int irq, void *arg)
 		if (hotplug_status)
 			i9xx_hpd_irq_handler(dev_priv, hotplug_status);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 		i915_pipestat_irq_handler(dev_priv, iir, pipe_stats);
+#endif
 	} while (0);
 
 	pmu_irq_stats(dev_priv, ret);
@@ -5626,6 +5726,7 @@ static void i965_irq_postinstall(struct drm_i915_private *dev_priv)
 	i915_enable_asle_pipestat(dev_priv);
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 static void i915_hpd_irq_setup(struct drm_i915_private *dev_priv)
 {
 	u32 hotplug_en;
@@ -5650,6 +5751,7 @@ static void i915_hpd_irq_setup(struct drm_i915_private *dev_priv)
 					     CRT_HOTPLUG_ACTIVATION_PERIOD_64,
 					     hotplug_en);
 }
+#endif
 
 static irqreturn_t i965_irq_handler(int irq, void *arg)
 {
@@ -5710,6 +5812,7 @@ static irqreturn_t i965_irq_handler(int irq, void *arg)
 	return ret;
 }
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 struct intel_hotplug_funcs {
 	void (*hpd_irq_setup)(struct drm_i915_private *i915);
 };
@@ -5734,6 +5837,7 @@ void intel_hpd_irq_setup(struct drm_i915_private *i915)
 	if (i915->display_irqs_enabled && i915->hotplug_funcs)
 		i915->hotplug_funcs->hpd_irq_setup(i915);
 }
+#endif
 
 /**
  * intel_irq_init - initializes irq support
@@ -5744,7 +5848,9 @@ void intel_hpd_irq_setup(struct drm_i915_private *i915)
  */
 void intel_irq_init(struct drm_i915_private *dev_priv)
 {
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	struct drm_device *dev = &dev_priv->drm;
+#endif
 	struct intel_gt *gt = to_root_gt(dev_priv);
 	int i;
 
@@ -5764,6 +5870,7 @@ void intel_irq_init(struct drm_i915_private *dev_priv)
 	if (HAS_GT_UC(dev_priv) && GRAPHICS_VER(dev_priv) < 11)
 		gt->pm_guc_events = GUC_INTR_GUC2HOST << 16;
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (!HAS_DISPLAY(dev_priv))
 		return;
 
@@ -5813,6 +5920,7 @@ void intel_irq_init(struct drm_i915_private *dev_priv)
 		else
 			dev_priv->hotplug_funcs = &ilk_hpd_funcs;
 	}
+#endif
 }
 
 /**
@@ -6012,7 +6120,9 @@ void intel_irq_uninstall(struct drm_i915_private *dev_priv)
 
 	free_irq(irq, dev_priv);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	intel_hpd_cancel_work(dev_priv);
+#endif
 	dev_priv->runtime_pm.irqs_enabled = false;
 }
 

--- a/drivers/gpu/drm/i915/intel_pm.c
+++ b/drivers/gpu/drm/i915/intel_pm.c
@@ -34,6 +34,7 @@
 #include <drm/drm_fourcc.h>
 #include <drm/drm_plane_helper.h>
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 #include "display/intel_atomic.h"
 #include "display/intel_atomic_plane.h"
 #include "display/intel_bw.h"
@@ -46,6 +47,7 @@
 #include "display/intel_sprite.h"
 #include "display/skl_universal_plane.h"
 #include "display/intel_cx0_phy.h"
+#endif
 
 #include "gt/intel_engine_regs.h"
 #include "gt/intel_gt.h"
@@ -4307,7 +4309,9 @@ skl_crtc_allocate_ddb(struct intel_atomic_state *state, struct intel_crtc *crtc)
 		intel_atomic_get_old_dbuf_state(state);
 	struct intel_dbuf_state *new_dbuf_state =
 		intel_atomic_get_new_dbuf_state(state);
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	struct intel_crtc_state *crtc_state;
+#endif
 	struct skl_ddb_entry ddb_slices;
 	enum pipe pipe = crtc->pipe;
 	unsigned int mbus_offset = 0;
@@ -4347,6 +4351,7 @@ out:
 	if (ret)
 		return ret;
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	crtc_state = intel_atomic_get_crtc_state(&state->base, crtc);
 	if (IS_ERR(crtc_state))
 		return PTR_ERR(crtc_state);
@@ -4357,6 +4362,7 @@ out:
 	 */
 	crtc_state->wm.skl.ddb.start = mbus_offset + new_dbuf_state->ddb[pipe].start;
 	crtc_state->wm.skl.ddb.end = mbus_offset + new_dbuf_state->ddb[pipe].end;
+#endif
 
 	drm_dbg_kms(&dev_priv->drm,
 		    "[CRTC:%d:%s] dbuf slices 0x%x -> 0x%x, ddb (%d - %d) -> (%d - %d), active pipes 0x%x -> 0x%x\n",

--- a/drivers/gpu/drm/i915/vlv_suspend.c
+++ b/drivers/gpu/drm/i915/vlv_suspend.c
@@ -462,8 +462,10 @@ int vlv_resume_prepare(struct drm_i915_private *dev_priv, bool rpm_resume)
 
 	vlv_check_no_gt_access(dev_priv);
 
+#if IS_ENABLED (CPTCFG_DRM_I915_DISPLAY)
 	if (rpm_resume)
 		intel_init_clock_gating(dev_priv);
+#endif
 
 	return ret;
 }


### PR DESCRIPTION
VMware DriverVM runs Intel GPU stack for server class hardware such as ATS-M in CRX environment. CRX uses a strip down version of the Linux kernel with no firmware, no ACPI or PM support, no framebuffer or UI except just serial console.

To reduce dependencies tree and to avoid bringing in unnecessary stuff, we cut display support out of i915 backport.

Introducing CPTCFG_DRM_I915_DISPLAY config option, by disabling the one we can build headless version of i915.