### PR TITLE
README: Update with Ubuntu 24.04 and vanilla 6.6lts info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ Each project is tagged consistently, so when pulling these repos, pull the same 
 | Red Hat® Enterprise Linux® 8.6       |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_redhat.md)| Yes | Yes |
 | SUSE® Linux® Enterprise Server 15SP5 |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_sles.md)| Yes | Yes |
 | SUSE® Linux® Enterprise Server 15SP4 |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_sles.md)| Yes | Yes |
+| Ubuntu® 24.04 Desktop (6.8 generic)  |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md)| Yes | Yes |
+| Ubuntu® 24.04 Server (6.8 generic)   |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md)| Yes | Yes |
 | Ubuntu® 22.04 Desktop (6.5 generic)  |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md)| Yes | Yes |
 | Ubuntu® 22.04 Server (5.15 generic)  |  [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_ubuntu.md)| Yes | Yes |
+| Vanilla Kernel (6.6 LTS)  | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_vanilla.md)| Yes | No |
 | Vanilla Kernel (6.1 LTS)  | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_vanilla.md)| Yes | No |
 | Vanilla Kernel (5.15 LTS) | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_vanilla.md)| Yes | No |
 | Vanilla Kernel (5.10 LTS) | [Readme](https://github.com/intel-gpu/intel-gpu-i915-backports/blob/backport/main/docs/README_vanilla.md)| Yes | No |


### PR DESCRIPTION
Update Supported OS Distributions table with Ubuntu 24.04 and
vanilla 6.6lts information.

Signed-off-by: Kanaka Raju Nayana <kanaka.raju.nayana@intel.com>