### PR TITLE
Correct Ubuntu README requirements

### DIFF
--- a/docs/README_ubuntu.md
+++ b/docs/README_ubuntu.md
@@ -18,7 +18,6 @@ Our current backport supports the following OS Distribution.
 
 ## Prerequisite
 We have dependencies on the following packages
-  - dkms
   - make
   - debhelper
   - devscripts
@@ -28,9 +27,9 @@ We have dependencies on the following packages
   - mawk
 
 ```
-$ sudo apt install dkms make debhelper devscripts build-essential flex bison mawk
+$ sudo apt install make debhelper devscripts build-essential flex bison mawk
 ```
-For DKMS modules, we need to install `dkms` package too.
+For i915 DKMS packages, we need to install `dkms` package too.
 ```
 $ sudo apt install dkms
 ```


### PR DESCRIPTION
Having dkms as requirement by default and then again for DKMS modules are causing confusion. 

Correct it out by removing dkms from default requirements

Signed-off-by: S A Muqthyar Ahmed <syed.abdul.muqthyar.ahmed@intel.com>